### PR TITLE
Require registration token for user registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 DATABASE_URL=postgresql://test:test@localhost:5432/example_app
 JWT_SECRET=your-super-secret-jwt-key-at-least-32-characters-long-for-testing
-ALLOW_REGISTRATION=true
+REGISTRATION_TOKEN=change-me-registration-secret
 PORT=3000

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 DATABASE_URL=postgresql://test:test@localhost:5432/example_app_test
 JWT_SECRET=your-super-secret-jwt-key-at-least-32-characters-long-for-testing
-ALLOW_REGISTRATION=true
+REGISTRATION_TOKEN=test-registration-token
 PORT=3000
 
 # On Mac, creating database users:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write   # needed to push bun.lock updates for Dependabot PRs
+  contents: write # needed to push bun.lock updates for Dependabot PRs
 
 jobs:
   tests:
@@ -38,14 +38,14 @@ jobs:
       NODE_ENV: test
       PORT: 3000
       TZ: America/Los_Angeles
-      ALLOW_REGISTRATION: true
+      REGISTRATION_TOKEN: test-registration-token
       FRONTEND_URL: http://localhost:4173
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # needed so we can push back to the PR branch
+          fetch-depth: 0 # needed so we can push back to the PR branch
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -5,10 +5,7 @@ const envSchema = z.object({
   JWT_SECRET: z.string().min(32),
   PORT: z.string().optional().default('3000'),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  ALLOW_REGISTRATION: z
-    .string()
-    .transform((val) => val === 'true')
-    .default('true'),
+  REGISTRATION_TOKEN: z.string().min(1).default(''),
   FRONTEND_URL: z.string().url().default('http://localhost:3000'),
 });
 

--- a/backend/src/tests/app.test.ts
+++ b/backend/src/tests/app.test.ts
@@ -142,7 +142,7 @@ describe('App Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(largePayload),
+        body: JSON.stringify({ ...largePayload, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -160,7 +160,7 @@ describe('App Integration Tests', () => {
       expect(res.status).toBe(200);
 
       const data = await res.json();
-      expect(data).toHaveProperty('enabled');
+      expect(data).toHaveProperty('required');
     });
 
     it('should return 404 for non-existent API routes', async () => {

--- a/backend/src/tests/auth-flow.test.ts
+++ b/backend/src/tests/auth-flow.test.ts
@@ -17,7 +17,7 @@ describe('Authentication Flow Integration Tests', () => {
       // Step 1: Register user
       const registerRes = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -74,7 +74,7 @@ describe('Authentication Flow Integration Tests', () => {
       // Register first user
       const res1 = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(user1Data),
+        body: JSON.stringify({ ...user1Data, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -86,7 +86,7 @@ describe('Authentication Flow Integration Tests', () => {
       // Register second user
       const res2 = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(user2Data),
+        body: JSON.stringify({ ...user2Data, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -116,7 +116,7 @@ describe('Authentication Flow Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -157,7 +157,7 @@ describe('Authentication Flow Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -183,6 +183,7 @@ describe('Authentication Flow Integration Tests', () => {
         body: JSON.stringify({
           ...userData,
           email: 'hash2@example.com',
+          registrationToken: process.env.REGISTRATION_TOKEN,
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -213,7 +214,7 @@ describe('Authentication Flow Integration Tests', () => {
 
         const res = await app.request('/api/users', {
           method: 'POST',
-          body: JSON.stringify(userData),
+          body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
           headers: {
             'Content-Type': 'application/json',
           },
@@ -251,6 +252,7 @@ describe('Authentication Flow Integration Tests', () => {
           body: JSON.stringify({
             ...userData,
             email: `tokensec${i}@example.com`,
+            registrationToken: process.env.REGISTRATION_TOKEN,
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -282,7 +284,7 @@ describe('Authentication Flow Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -316,7 +318,7 @@ describe('Authentication Flow Integration Tests', () => {
       const promises = Array.from({ length: 3 }, () =>
         app.request('/api/users', {
           method: 'POST',
-          body: JSON.stringify(userData),
+          body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
           headers: {
             'Content-Type': 'application/json',
           },
@@ -346,7 +348,7 @@ describe('Authentication Flow Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },

--- a/backend/src/tests/users.test.ts
+++ b/backend/src/tests/users.test.ts
@@ -14,8 +14,8 @@ describe('Users API Integration Tests', () => {
 
       expect(res.status).toBe(200);
       const data = await res.json();
-      expect(data).toHaveProperty('enabled');
-      expect(typeof data.enabled).toBe('boolean');
+      expect(data).toHaveProperty('required');
+      expect(typeof data.required).toBe('boolean');
     });
   });
 
@@ -29,7 +29,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -66,7 +66,7 @@ describe('Users API Integration Tests', () => {
       // Create first user
       const firstRes = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -79,6 +79,7 @@ describe('Users API Integration Tests', () => {
         body: JSON.stringify({
           ...userData,
           name: 'Different Name',
+          registrationToken: process.env.REGISTRATION_TOKEN,
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -104,7 +105,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -130,7 +131,7 @@ describe('Users API Integration Tests', () => {
       for (const userData of testCases) {
         const res = await app.request('/api/users', {
           method: 'POST',
-          body: JSON.stringify(userData),
+          body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
           headers: {
             'Content-Type': 'application/json',
           },
@@ -158,7 +159,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -182,7 +183,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -250,7 +251,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -285,7 +286,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -344,7 +345,7 @@ describe('Users API Integration Tests', () => {
 
       const res = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -374,7 +375,7 @@ describe('Users API Integration Tests', () => {
 
       const registerRes = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -441,7 +442,7 @@ describe('Users API Integration Tests', () => {
 
       const registerRes = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -479,7 +480,7 @@ describe('Users API Integration Tests', () => {
 
       const registerRes = await app.request('/api/users', {
         method: 'POST',
-        body: JSON.stringify(userData),
+        body: JSON.stringify({ ...userData, registrationToken: process.env.REGISTRATION_TOKEN }),
         headers: {
           'Content-Type': 'application/json',
         },

--- a/backend/src/validation/users.ts
+++ b/backend/src/validation/users.ts
@@ -14,6 +14,7 @@ export const registerSchema = z.object({
   email: z.string().min(1, 'Email is required').email('Invalid email format'),
 
   password: z.string().min(6, 'Password must be at least 6 characters'),
+  registrationToken: z.string().optional(),
 });
 
 // Login schema

--- a/copilot/prd-auth-template.md
+++ b/copilot/prd-auth-template.md
@@ -14,7 +14,7 @@ This document outlines the requirements for a streamlined authentication system 
 
 ## User Stories
 
-1. **Registration:** As a new user, I want to register for an account when registration is enabled, so that I can access the application.
+1. **Registration:** As a new user, I want to register for an account using a registration token when required, so that only invited users can access the application.
 2. **Login:** As a registered user, I want to log in to the application, so that I can access my account.
 3. **Remembered Login:** As a returning user, I want the option to stay logged in, so that I don't have to re-enter my credentials every time I visit the site.
 4. **Registration Restriction:** As a system administrator, I want to control when user registration is available, so that I can manage access to the application.
@@ -31,7 +31,7 @@ This document outlines the requirements for a streamlined authentication system 
 3. The system must perform server-side validation of all fields with the same requirements.
 4. The system must check for existing users with the same email and reject registrations with duplicate emails.
 5. The system must securely hash passwords before storing them in the database.
-6. The system must only allow registration when the environment variable `ALLOW_REGISTRATION` is set to "true".
+6. The system must only allow registration when the user supplies the correct `REGISTRATION_TOKEN` value configured in the environment. If the token is blank, registration is disabled.
 7. The system must return appropriate error messages for validation failures.
 8. The system must create a new user record in the database upon successful registration.
 9. The system must issue a JWT token upon successful registration and log the user in automatically.
@@ -97,5 +97,5 @@ This document outlines the requirements for a streamlined authentication system 
    - Test both backend API endpoints and frontend interactions
 
 4. **Environment Configuration:**
-   - Implement `ALLOW_REGISTRATION` environment variable to control registration availability
+   - Implement `REGISTRATION_TOKEN` environment variable; when set (non-empty) it is required for registration; when unset/empty registration is disabled
    - Store JWT secret in environment variables

--- a/copilot/tasks-prd-auth-template.md
+++ b/copilot/tasks-prd-auth-template.md
@@ -10,7 +10,7 @@ This task list is generated based on the requirements in the [Authentication Tem
   - [x] 1.3 Implement server-side validation for registration fields
   - [x] 1.4 Add duplicate email check in registration process
   - [x] 1.5 Implement password hashing mechanism
-  - [x] 1.6 Add environment variable check for `ALLOW_REGISTRATION` flag
+  - [x] 1.6 Add environment variable gate via `REGISTRATION_TOKEN` (required for registration)
   - [x] 1.7 Create frontend registration form component with all required fields
   - [x] 1.8 Implement client-side form validation for registration
   - [x] 1.9 Connect frontend form to backend API endpoint

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
     environment:
       DATABASE_URL: postgres://test:test@test-db:5432/example_app
       JWT_SECRET: your-super-secret-jwt-key-at-least-32-characters-long-for-testing
-      ALLOW_REGISTRATION: true
+      REGISTRATION_TOKEN: test-registration-token
       PORT: 3000
       FRONTEND_URL: http://localhost:3000
     ports:

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -10,7 +10,7 @@ interface AuthResponse {
 // Type-safe authentication API using Hono client
 export const authApi = {
   // Check if registration is enabled
-  async getRegistrationStatus(): Promise<{ enabled: boolean }> {
+  async getRegistrationStatus(): Promise<{ enabled: boolean; required: boolean }> {
     const response = await api.api.users['registration-status'].$get();
     if (!response.ok) {
       throw new Error('Failed to check registration status');
@@ -19,7 +19,7 @@ export const authApi = {
   },
 
   // Register a new user
-  async register(data: { name: string; email: string; password: string }): Promise<AuthResponse> {
+  async register(data: { name: string; email: string; password: string; registrationToken?: string }): Promise<AuthResponse> {
     const response = await api.api.users.$post({
       json: data,
     });

--- a/frontend/src/lib/components/auth/RegisterForm.svelte
+++ b/frontend/src/lib/components/auth/RegisterForm.svelte
@@ -4,7 +4,9 @@
   // Props
   export let loading = false;
   export let error: string | null = null;
-  export let registrationEnabled = true;
+  export let registrationTokenRequired = false;
+  export let registrationEnabled = false;
+  export let registrationToken: string = '';
 
   // Form data
   let name = '';
@@ -19,7 +21,7 @@
 
   // Event dispatcher
   const dispatch = createEventDispatcher<{
-    register: { name: string; email: string; password: string };
+    register: { name: string; email: string; password: string; registrationToken?: string };
   }>();
 
   // Validate form input
@@ -72,7 +74,7 @@
   // Handle form submission
   function handleSubmit() {
     if (validateForm()) {
-      dispatch('register', { name, email, password });
+      dispatch('register', { name, email, password, registrationToken: registrationTokenRequired ? registrationToken : undefined });
     }
   }
 </script>
@@ -83,8 +85,8 @@
     <p class="text-base-content/70">Join today to get started</p>
   </div>
 
-  {#if !registrationEnabled}
-    <div class="alert alert-warning mb-6">
+  {#if registrationTokenRequired}
+    <div class="alert alert-info mb-6">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="20"
@@ -97,11 +99,11 @@
         stroke-linejoin="round"
         class="h-5 w-5"
       >
-        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path>
-        <path d="M12 9v4"></path>
-        <path d="M12 17h.01"></path>
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" x2="12" y1="8" y2="12" />
+        <line x1="12" x2="12.01" y1="16" y2="16" />
       </svg>
-      <span>Registration is currently disabled</span>
+      <span>A registration token is required to create an account.</span>
     </div>
   {/if}
 
@@ -196,8 +198,28 @@
       </label>
     </div>
 
+    {#if registrationTokenRequired}
+      <div class="form-control">
+        <label class="label" for="registrationToken">
+          <span class="label-text">Registration Token</span>
+        </label>
+        <input
+          type="text"
+          id="registrationToken"
+          bind:value={registrationToken}
+          placeholder="Enter provided token"
+          class="input input-bordered w-full"
+          disabled={loading || !registrationEnabled}
+          autocomplete="off"
+        />
+        <label class="label">
+          <span class="label-text-alt text-base-content/60">Ask the administrator for the token</span>
+        </label>
+      </div>
+    {/if}
+
     <div class="form-control mt-6">
-      <button type="submit" class="btn btn-primary w-full" disabled={loading || !registrationEnabled}>
+      <button type="submit" class="btn btn-primary w-full" disabled={loading || !registrationEnabled || (registrationTokenRequired && !registrationToken)}>
         {#if loading}
           <span class="loading loading-spinner loading-sm"></span>
         {/if}

--- a/tests/e2e/auth-persistence.spec.ts
+++ b/tests/e2e/auth-persistence.spec.ts
@@ -20,6 +20,11 @@ test.describe('Authentication Persistence', () => {
     await page.fill('#email', email);
     await page.fill('#password', password);
 
+    // If a registration token field is present, fill it
+    if (await page.$('#registrationToken')) {
+      await page.fill('#registrationToken', process.env.REGISTRATION_TOKEN || 'test-registration-token');
+    }
+
     await page.click('button[type="submit"]');
     await page.waitForURL('/', { timeout: TEST_CONFIG.TIMEOUTS.LOGIN });
 

--- a/tests/e2e/registration.spec.ts
+++ b/tests/e2e/registration.spec.ts
@@ -8,13 +8,17 @@ test.describe('User Registration', () => {
     // Wait for the form to be visible
     await page.waitForSelector('form');
 
-    // Make sure registration is enabled (using mock API or environment variable)
-    // This test assumes the backend is configured with ALLOW_REGISTRATION=true
+    // Provide registration token if required by backend configuration
 
     // Fill out the registration form
     await page.fill('#name', 'Test User');
     await page.fill('#email', `test-${Date.now()}@example.com`); // Unique email
     await page.fill('#password', 'password123');
+
+    // If token field exists, fill it
+    if (await page.$('#registrationToken')) {
+      await page.fill('#registrationToken', process.env.REGISTRATION_TOKEN || 'test-registration-token');
+    }
 
     // Submit the form
     await page.click('button[type="submit"]');
@@ -33,8 +37,13 @@ test.describe('User Registration', () => {
     // Wait for the form to be visible
     await page.waitForSelector('form');
 
-    // Submit an empty form
-    await page.click('button[type="submit"]');
+    // If a registration token field is present, fill it so the submit button is enabled for validation
+    if (await page.$('#registrationToken')) {
+      await page.fill('#registrationToken', process.env.REGISTRATION_TOKEN || 'test-registration-token');
+    }
+
+    const submitButton = page.locator('button[type="submit"]');
+    await submitButton.click();
 
     // Verify validation errors are displayed
     await expect(page.locator('text=Name is required')).toBeVisible();
@@ -46,8 +55,7 @@ test.describe('User Registration', () => {
     await page.fill('#email', 'invalid-email');
     await page.fill('#password', '12345'); // Too short
 
-    // Submit the form
-    await page.click('button[type="submit"]');
+    await submitButton.click();
 
     // Verify validation errors for invalid data
     await expect(page.locator('text=valid email')).toBeVisible();
@@ -65,6 +73,10 @@ test.describe('User Registration', () => {
     await page.fill('#name', 'Test User');
     await page.fill('#email', email);
     await page.fill('#password', 'password123');
+
+    if (await page.$('#registrationToken')) {
+      await page.fill('#registrationToken', process.env.REGISTRATION_TOKEN || 'test-registration-token');
+    }
 
     // Submit the form
     await page.click('button[type="submit"]');
@@ -87,6 +99,10 @@ test.describe('User Registration', () => {
     await page.fill('#name', 'Another User');
     await page.fill('#email', email);
     await page.fill('#password', 'password456');
+
+    if (await page.$('#registrationToken')) {
+      await page.fill('#registrationToken', process.env.REGISTRATION_TOKEN || 'test-registration-token');
+    }
 
     // Submit the form
     await page.click('button[type="submit"]');
@@ -118,8 +134,8 @@ test.describe('User Registration', () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
-    // Verify the disabled message is shown
-    await expect(page.locator('text=Registration is currently disabled')).toBeVisible();
+    // Verify the page reflects disabled registration (alert or disabled button)
+    await expect(page.locator('button[type="submit"]')).toBeDisabled();
 
     // Verify the form is disabled
     await expect(page.locator('button[type="submit"]')).toBeDisabled();

--- a/tests/e2e/seed-data.ts
+++ b/tests/e2e/seed-data.ts
@@ -44,6 +44,8 @@ async function createTestUser() {
       name: TEST_CONFIG.USER.username,
       email: TEST_CONFIG.USER.email,
       password: TEST_CONFIG.USER.password,
+      // Provide registration token required by backend if set in environment; default test token
+      registrationToken: process.env.REGISTRATION_TOKEN || 'test-registration-token',
     }),
   });
 


### PR DESCRIPTION
Implement a registration token requirement for user registration, replacing the previous `ALLOW_REGISTRATION` flag. This change enhances security by ensuring only users with the correct token can register. Update the environment configuration and related schemas accordingly.